### PR TITLE
Avoid use ssh for dependency checkout.

### DIFF
--- a/cmake/implicit_functions.cmake
+++ b/cmake/implicit_functions.cmake
@@ -5,7 +5,7 @@ endif()
 include(FetchContent)
 FetchContent_Declare(
     implicit_functions
-    GIT_REPOSITORY git@github.com:duxingyi-charles/implicit_functions.git
+    GIT_REPOSITORY https://github.com/duxingyi-charles/implicit_functions.git
     GIT_TAG main
     )
 

--- a/cmake/simplicial_arrangement.cmake
+++ b/cmake/simplicial_arrangement.cmake
@@ -5,7 +5,7 @@ endif()
 include(FetchContent)
 FetchContent_Declare(
     simplicial_arrangement
-    GIT_REPOSITORY git@github.com:qnzhou/simplicial_arrangement.git
+    GIT_REPOSITORY https://github.com/qnzhou/simplicial_arrangement.git
     GIT_TAG main
     )
 


### PR DESCRIPTION
Summary:
* Avoid using ssh to checkout dependencies.