### PR TITLE
Add support for relative path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ include(nlohmann-json)
 include(Eigen3)
 include(mshio)
 include(implicit_functions)
+include(filesystem)
 
 
 # implicit function utility
@@ -25,7 +26,8 @@ target_include_directories(robust_implicit_networks PUBLIC
 target_compile_features(robust_implicit_networks PRIVATE cxx_std_17)
 target_link_libraries(robust_implicit_networks
      PUBLIC simplicial_arrangement::simplicial_arrangement Eigen3::Eigen
-        nlohmann_json::nlohmann_json absl::flat_hash_map absl::flat_hash_set mshio::mshio)
+        nlohmann_json::nlohmann_json absl::flat_hash_map absl::flat_hash_set
+        mshio::mshio ghc::filesystem)
 #         absl::numeric absl::flat_hash_map )
 
 

--- a/cmake/filesystem.cmake
+++ b/cmake/filesystem.cmake
@@ -1,0 +1,12 @@
+if(TARGET ghc::filesystem)
+    return()
+endif()
+
+include(FetchContent)
+FetchContent_Declare(
+    filesystem
+    GIT_REPOSITORY https://github.com/gulrak/filesystem.git
+    GIT_TAG v1.5.12
+)
+FetchContent_MakeAvailable(filesystem)
+add_library(ghc::filesystem ALIAS ghc_filesystem)

--- a/examples/implicit_arrangement/config.json
+++ b/examples/implicit_arrangement/config.json
@@ -1,7 +1,7 @@
 {
-	"tetMeshFile":"\/Users\/charlesdu\/Downloads\/research\/implicit_modeling\/code\/sig22-implicit-surface-networks\/Robust_Implicit_Surface_Networks\/examples\/tet_mesh\/tet5_grid_10k.json",
-	"funcFile":"\/Users\/charlesdu\/Downloads\/research\/implicit_modeling\/code\/sig22-implicit-surface-networks\/Robust_Implicit_Surface_Networks\/examples\/implicit_arrangement\/18-sphere.json",
-	"outputDir":"\/Users\/charlesdu\/Downloads\/research\/implicit_modeling\/code\/sig22-implicit-surface-networks\/Robust_Implicit_Surface_Networks\/examples\/implicit_arrangement",
+	"tetMeshFile":"../tet_mesh/tet5_grid_10k.json",
+	"funcFile":"18-sphere.json",
+	"outputDir":"./",
 	"useLookup":true,
 	"use2funcLookup":true,
 	"useTopoRayShooting":true

--- a/examples/material_interface/config.json
+++ b/examples/material_interface/config.json
@@ -1,7 +1,7 @@
 {
-	"tetMeshFile":"\/Users\/charlesdu\/Downloads\/research\/implicit_modeling\/code\/sig22-implicit-surface-networks\/Robust_Implicit_Surface_Networks\/examples\/tet_mesh\/tet5_grid_10k.json",
-	"materialFile":"\/Users\/charlesdu\/Downloads\/research\/implicit_modeling\/code\/sig22-implicit-surface-networks\/Robust_Implicit_Surface_Networks\/examples\/material_interface\/18-sphere.json",
-	"outputDir":"\/Users\/charlesdu\/Downloads\/research\/implicit_modeling\/code\/sig22-implicit-surface-networks\/Robust_Implicit_Surface_Networks\/examples\/material_interface",
+	"tetMeshFile":"../tet_mesh/tet5_grid_10k.json",
+	"materialFile":"18-sphere.json",
+	"outputDir":"./",
 	"useLookup":true,
 	"use3funcLookup":true,
 	"useTopoRayShooting":true

--- a/src/io.cpp
+++ b/src/io.cpp
@@ -7,6 +7,7 @@
 
 #include <fstream>
 #include <iostream>
+#include <ghc/filesystem.hpp>
 
 bool parse_config_file(const std::string& filename,
                        std::string& tet_mesh_file,
@@ -17,6 +18,7 @@ bool parse_config_file(const std::string& filename,
                        bool& use_topo_ray_shooting)
 {
     using json = nlohmann::json;
+    namespace fs = ghc::filesystem;
     std::ifstream fin(filename.c_str());
     if (!fin) {
         std::cout << "configure file not exist!" << std::endl;
@@ -25,10 +27,26 @@ bool parse_config_file(const std::string& filename,
     json data;
     fin >> data;
     fin.close();
-    //
-    tet_mesh_file = data["tetMeshFile"];
-    func_file = data["funcFile"];
-    output_dir = data["outputDir"];
+
+    fs::path config_file(filename);
+    fs::path function_file(data["funcFile"]);
+    fs::path tet_file(data["tetMeshFile"]);
+    fs::path out_dir(data["outputDir"]);
+
+    fs::path config_path = config_file.parent_path();
+    if (function_file.is_relative()) {
+        function_file = fs::absolute(config_path / function_file);
+    }
+    if (tet_file.is_relative()) {
+        tet_file = fs::absolute(config_path / tet_file);
+    }
+    if (out_dir.is_relative()) {
+        out_dir= fs::absolute(config_path / out_dir);
+    }
+
+    tet_mesh_file = tet_file.string();
+    func_file = function_file.string();
+    output_dir = out_dir.string();
     use_lookup = data["useLookup"];
     use_2func_lookup = data["use2funcLookup"];
     use_topo_ray_shooting = data["useTopoRayShooting"];
@@ -44,6 +62,7 @@ bool parse_config_file_MI(const std::string& filename,
                           bool& use_topo_ray_shooting)
 {
     using json = nlohmann::json;
+    namespace fs = ghc::filesystem;
     std::ifstream fin(filename.c_str());
     if (!fin) {
         std::cout << "configure file not exist!" << std::endl;
@@ -52,10 +71,26 @@ bool parse_config_file_MI(const std::string& filename,
     json data;
     fin >> data;
     fin.close();
-    //
-    tet_mesh_file = data["tetMeshFile"];
-    material_file = data["materialFile"];
-    output_dir = data["outputDir"];
+
+    fs::path config_file(filename);
+    fs::path tet_file(data["tetMeshFile"]);
+    fs::path mat_file(data["materialFile"]);
+    fs::path out_dir(data["outputDir"]);
+
+    fs::path config_path = config_file.parent_path();
+    if (mat_file.is_relative()) {
+        mat_file = fs::absolute(config_path / mat_file);
+    }
+    if (tet_file.is_relative()) {
+        tet_file = fs::absolute(config_path / tet_file);
+    }
+    if (out_dir.is_relative()) {
+        out_dir= fs::absolute(config_path / out_dir);
+    }
+
+    tet_mesh_file = tet_file.string();
+    material_file = mat_file.string();
+    output_dir = out_dir.string();
     use_lookup = data["useLookup"];
     use_3func_lookup = data["use3funcLookup"];
     use_topo_ray_shooting = data["useTopoRayShooting"];


### PR DESCRIPTION
Summary:
* A minor usability improvement: when a relative path is used in the config file, it is interpreted as it is relative to the parent directory that contains the config file.

With this change, the example config files are more readable and they can be run without changing the config file.