### PR TITLE
Add support for tet grid generation

### DIFF
--- a/app/implicit_arrangement.cpp
+++ b/app/implicit_arrangement.cpp
@@ -36,13 +36,15 @@ int main(int argc, const char* argv[])
     bool use_lookup = true;
     bool use_2func_lookup = true;
     bool use_topo_ray_shooting = true;
+    size_t tet_mesh_resolution = 0;
     parse_config_file(args.config_file,
                       tet_mesh_file,
                       func_file,
                       output_dir,
                       use_lookup,
                       use_2func_lookup,
-                      use_topo_ray_shooting);
+                      use_topo_ray_shooting,
+                      tet_mesh_resolution);
     if (use_lookup) {
         // load lookup table
         std::cout << "load table ..." << std::endl;
@@ -69,7 +71,14 @@ int main(int argc, const char* argv[])
     // load tet mesh
     std::vector<std::array<double, 3>> pts;
     std::vector<std::array<size_t, 4>> tets;
-    load_tet_mesh(tet_mesh_file, pts, tets);
+    if (tet_mesh_file != "") {
+        std::cout << "load mesh file " << tet_mesh_file << std::endl;
+        load_tet_mesh(tet_mesh_file, pts, tets);
+    } else {
+        std::cout << "generating mesh with resolution "
+            << tet_mesh_resolution << std::endl;
+        generate_tet_mesh(tet_mesh_resolution, pts, tets);
+    }
     size_t n_tets = tets.size();
     size_t n_pts = pts.size();
     std::cout << "tet mesh: " << n_pts << " verts, " << n_tets << " tets." << std::endl;

--- a/app/implicit_arrangement.cpp
+++ b/app/implicit_arrangement.cpp
@@ -30,22 +30,9 @@ int main(int argc, const char* argv[])
     CLI11_PARSE(app, argc, argv);
 
     // parse configure file
-    std::string tet_mesh_file;
-    std::string func_file;
-    std::string output_dir;
-    bool use_lookup = true;
-    bool use_2func_lookup = true;
-    bool use_topo_ray_shooting = true;
-    size_t tet_mesh_resolution = 0;
-    parse_config_file(args.config_file,
-                      tet_mesh_file,
-                      func_file,
-                      output_dir,
-                      use_lookup,
-                      use_2func_lookup,
-                      use_topo_ray_shooting,
-                      tet_mesh_resolution);
-    if (use_lookup) {
+    Config config = parse_config_file(args.config_file);
+
+    if (config.use_lookup) {
         // load lookup table
         std::cout << "load table ..." << std::endl;
         bool loaded = load_lookup_table();
@@ -57,7 +44,7 @@ int main(int argc, const char* argv[])
         }
     } else {
         disable_lookup_table();
-        use_2func_lookup = false;
+        config.use_secondary_lookup = false;
     }
 
     // record timings
@@ -71,13 +58,14 @@ int main(int argc, const char* argv[])
     // load tet mesh
     std::vector<std::array<double, 3>> pts;
     std::vector<std::array<size_t, 4>> tets;
-    if (tet_mesh_file != "") {
-        std::cout << "load mesh file " << tet_mesh_file << std::endl;
-        load_tet_mesh(tet_mesh_file, pts, tets);
+    if (config.tet_mesh_file != "") {
+        std::cout << "load mesh file " << config.tet_mesh_file << std::endl;
+        load_tet_mesh(config.tet_mesh_file, pts, tets);
     } else {
         std::cout << "generating mesh with resolution "
-            << tet_mesh_resolution << std::endl;
-        generate_tet_mesh(tet_mesh_resolution, pts, tets);
+            << config.tet_mesh_resolution << std::endl;
+        generate_tet_mesh(config.tet_mesh_resolution, config.tet_mesh_bbox_min,
+                config.tet_mesh_bbox_max, pts, tets);
     }
     size_t n_tets = tets.size();
     size_t n_pts = pts.size();
@@ -89,7 +77,7 @@ int main(int argc, const char* argv[])
 
     // load implicit functions and compute function values at vertices
     Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> funcVals;
-    if (load_functions(func_file, pts, funcVals)) {
+    if (load_functions(config.func_file, pts, funcVals)) {
         std::cout << "function loading finished." << std::endl;
     } else {
         std::cout << "function loading failed." << std::endl;
@@ -215,7 +203,7 @@ int main(int argc, const char* argv[])
                 }
                 //
                 bool crashed = false;
-                if (use_lookup && !use_2func_lookup && num_func == 2) {
+                if (config.use_lookup && !config.use_secondary_lookup && num_func == 2) {
                     cut_result_index.push_back(cut_results.size());
                     disable_lookup_table();
                     try {
@@ -317,7 +305,7 @@ int main(int argc, const char* argv[])
                         plane[3] = funcVals(v4, f_id);
                     }
                     //
-                    if (use_lookup && !use_2func_lookup && num_func == 2) {
+                    if (config.use_lookup && !config.use_secondary_lookup && num_func == 2) {
                         cut_result_index.push_back(cut_results.size());
                         disable_lookup_table();
                         cut_results.emplace_back(std::move(compute_arrangement(planes)));
@@ -397,7 +385,7 @@ int main(int argc, const char* argv[])
     {
         timing_labels.emplace_back("extract mesh");
         ScopedTimer<> timer("extract mesh");
-        if (use_topo_ray_shooting) {
+        if (config.use_topo_ray_shooting) {
             extract_iso_mesh(num_1_func,
                                   num_2_func,
                                   num_more_func,
@@ -609,7 +597,7 @@ int main(int argc, const char* argv[])
                 arrangement_cells.back()[0] = i;
             }
         } else { // resolve nesting order
-            if (use_topo_ray_shooting) {
+            if (config.use_topo_ray_shooting) {
                 timing_labels.emplace_back("arrCells(ray shooting)");
                 ScopedTimer<> timer("arrangement cells: topo ray shooting");
                 topo_ray_shooting(pts, tets,
@@ -666,7 +654,7 @@ int main(int argc, const char* argv[])
     if (components.size() > 1) {
         timing_labels.back() = "arrCells(other)";
         size_t num_timings = timings.size();
-        if (use_topo_ray_shooting) {
+        if (config.use_topo_ray_shooting) {
             timings.back() = timings[num_timings - 1] - timings[num_timings - 2];
         } else {
             // baseline: group simplicial cells into arrangement cells
@@ -676,7 +664,7 @@ int main(int argc, const char* argv[])
 
     // test: export iso-mesh, patches, chains
     if (!args.timing_only) {
-        save_result(output_dir + "/mesh.json",
+        save_result(config.output_dir + "/mesh.json",
                     iso_pts,
                     iso_faces,
                     patches,
@@ -686,7 +674,7 @@ int main(int argc, const char* argv[])
                     shells,
                     arrangement_cells);
         //
-        save_result_msh(output_dir + "/mesh",
+        save_result_msh(config.output_dir + "/mesh",
                         iso_pts,
                         iso_faces,
                         patches,
@@ -697,9 +685,9 @@ int main(int argc, const char* argv[])
                         arrangement_cells);
     }
     // save timing records
-    save_timings(output_dir + "/timings.json", timing_labels, timings);
+    save_timings(config.output_dir + "/timings.json", timing_labels, timings);
     // save statistics
-    save_statistics(output_dir + "/stats.json", stats_labels, stats);
+    save_statistics(config.output_dir + "/stats.json", stats_labels, stats);
 
 
     return 0;

--- a/app/material_interface.cpp
+++ b/app/material_interface.cpp
@@ -41,8 +41,10 @@ int main(int argc, const char* argv[])
     bool use_lookup = true;
     bool use_3func_lookup = true;
     bool use_topo_ray_shooting = true;
+    size_t tet_mesh_resolution = 0;
     parse_config_file_MI(args.config_file, tet_mesh_file, material_file, output_dir,
-                         use_lookup, use_3func_lookup, use_topo_ray_shooting);
+                         use_lookup, use_3func_lookup, use_topo_ray_shooting,
+                         tet_mesh_resolution);
     if (use_lookup) {
         // load lookup table
         std::cout << "load table ..." << std::endl;
@@ -69,7 +71,14 @@ int main(int argc, const char* argv[])
     // load tet mesh
     std::vector<std::array<double, 3>> pts;
     std::vector<std::array<size_t, 4>> tets;
-    load_tet_mesh(tet_mesh_file, pts, tets);
+    if (tet_mesh_file != "") {
+        std::cout << "load mesh file " << tet_mesh_file << std::endl;
+        load_tet_mesh(tet_mesh_file, pts, tets);
+    } else {
+        std::cout << "generating mesh with resolution "
+            << tet_mesh_resolution << std::endl;
+        generate_tet_mesh(tet_mesh_resolution, pts, tets);
+    }
     size_t n_tets = tets.size();
     size_t n_pts = pts.size();
     std::cout << "tet mesh: " << n_pts << " verts, " << n_tets << " tets." << std::endl;

--- a/examples/implicit_arrangement/config.json
+++ b/examples/implicit_arrangement/config.json
@@ -1,9 +1,10 @@
 {
-	"resolution": 10,
+	"gridResolution": 10,
+	"gridBbox": [[-1, -1, -1], [1, 1, 1]],
     "#tetMeshFile": "../tet_mesh/tet5_grid_10k.json",
 	"funcFile":"18-sphere.json",
 	"outputDir":"./",
 	"useLookup":true,
-	"use2funcLookup":true,
+	"useSecondaryLookup":true,
 	"useTopoRayShooting":true
 }

--- a/examples/implicit_arrangement/config.json
+++ b/examples/implicit_arrangement/config.json
@@ -1,5 +1,6 @@
 {
-	"tetMeshFile":"../tet_mesh/tet5_grid_10k.json",
+	"resolution": 10,
+    "#tetMeshFile": "../tet_mesh/tet5_grid_10k.json",
 	"funcFile":"18-sphere.json",
 	"outputDir":"./",
 	"useLookup":true,

--- a/examples/implicit_arrangement/config.json
+++ b/examples/implicit_arrangement/config.json
@@ -1,7 +1,7 @@
 {
-	"gridResolution": 10,
+	"gridResolution": 21,
 	"gridBbox": [[-1, -1, -1], [1, 1, 1]],
-    "#tetMeshFile": "../tet_mesh/tet5_grid_10k.json",
+	"#tetMeshFile": "../tet_mesh/tet5_grid_10k.json",
 	"funcFile":"18-sphere.json",
 	"outputDir":"./",
 	"useLookup":true,

--- a/examples/material_interface/config.json
+++ b/examples/material_interface/config.json
@@ -1,6 +1,6 @@
 {
 	"gridResolution": 21,
-    "gridBbox": [[-1, -1, -1], [1, 1, 1]],
+	"gridBbox": [[-1, -1, -1], [1, 1, 1]],
 	"funcFile":"18-sphere.json",
 	"outputDir":"./",
 	"useLookup":true,

--- a/examples/material_interface/config.json
+++ b/examples/material_interface/config.json
@@ -1,5 +1,5 @@
 {
-	"tetMeshFile":"../tet_mesh/tet5_grid_10k.json",
+	"resolution": 21,
 	"materialFile":"18-sphere.json",
 	"outputDir":"./",
 	"useLookup":true,

--- a/examples/material_interface/config.json
+++ b/examples/material_interface/config.json
@@ -1,8 +1,9 @@
 {
-	"resolution": 21,
-	"materialFile":"18-sphere.json",
+	"gridResolution": 21,
+    "gridBbox": [[-1, -1, -1], [1, 1, 1]],
+	"funcFile":"18-sphere.json",
 	"outputDir":"./",
 	"useLookup":true,
-	"use3funcLookup":true,
+	"useSecondaryLookup":true,
 	"useTopoRayShooting":true
 }

--- a/src/io.h
+++ b/src/io.h
@@ -9,31 +9,33 @@
 #include <nlohmann/json.hpp>
 #include "mesh.h"
 
-// parse config file for Implicit Arrangement
-bool parse_config_file(const std::string &filename,
-                       std::string& tet_mesh_file,
-                       std::string& func_file,
-                       std::string& output_dir,
-                       bool& use_lookup,
-                       bool& use_2func_lookup,
-                       bool& use_topo_ray_shooting,
-                       size_t& tet_mesh_resolution);
+struct Config {
+    // Input
+    std::string tet_mesh_file;
+    std::string func_file;
+    std::string output_dir;
 
-// parse config file for Material Interface
-bool parse_config_file_MI(const std::string& filename,
-                          std::string& tet_mesh_file,
-                          std::string& material_file,
-                          std::string& output_dir,
-                          bool& use_lookup,
-                          bool& use_3func_lookup,
-                          bool& use_topo_ray_shooting,
-                          size_t& tet_mesh_resolution);
+    // Lookup setting.
+    bool use_lookup;
+    bool use_secondary_lookup;
+    bool use_topo_ray_shooting;
+
+    // Parameter for tet grid generation.
+    // (Only used if tet_mesh_file is empty.)
+    size_t tet_mesh_resolution;
+    std::array<double, 3> tet_mesh_bbox_min;
+    std::array<double, 3> tet_mesh_bbox_max;
+};
+
+Config parse_config_file(const std::string &filename);
 
 bool load_tet_mesh(const std::string &filename,
                    std::vector<std::array<double, 3>> &pts,
                    std::vector<std::array<size_t, 4>> &tets);
 
 bool generate_tet_mesh(size_t resolution,
+                   const std::array<double, 3>& bbox_min,
+                   const std::array<double, 3>& bbox_max,
                    std::vector<std::array<double, 3>> &pts,
                    std::vector<std::array<size_t, 4>> &tets);
 

--- a/src/io.h
+++ b/src/io.h
@@ -16,7 +16,8 @@ bool parse_config_file(const std::string &filename,
                        std::string& output_dir,
                        bool& use_lookup,
                        bool& use_2func_lookup,
-                       bool& use_topo_ray_shooting);
+                       bool& use_topo_ray_shooting,
+                       size_t& tet_mesh_resolution);
 
 // parse config file for Material Interface
 bool parse_config_file_MI(const std::string& filename,
@@ -25,9 +26,14 @@ bool parse_config_file_MI(const std::string& filename,
                           std::string& output_dir,
                           bool& use_lookup,
                           bool& use_3func_lookup,
-                          bool& use_topo_ray_shooting);
+                          bool& use_topo_ray_shooting,
+                          size_t& tet_mesh_resolution);
 
 bool load_tet_mesh(const std::string &filename,
+                   std::vector<std::array<double, 3>> &pts,
+                   std::vector<std::array<size_t, 4>> &tets);
+
+bool generate_tet_mesh(size_t resolution,
                    std::vector<std::array<double, 3>> &pts,
                    std::vector<std::array<size_t, 4>> &tets);
 


### PR DESCRIPTION
### Summary:
* Add support to generate tet mesh grid given the grid resolution and bbox.  This is only used if the config file does not specify a tet mesh file.
* Refactor and cleanup config loading code.
* Update existing examples.

### Change to config format:
The following new fields are supported:
* `gridResolution`: (int), it specifies the gird resolution N, which will generate a NxNxN grid made of tets.
* `gridBbox`: (array), it specifies the bbox of the grid.  e.g. `[[-1, -1, -1], [1, 1, 1]]`.

The following fields are changed:
* `use2funcLookup` in IA and `use3funcLookup` in MI are renamed as `useSecondaryLookup`.
* `materialFile` in MI is renamed to `funcFile`.

These renaming is necessary to support unified config file for both IA and MI.