### PR TITLE
added feature to propagate function signs to all cells and its accord…

### DIFF
--- a/app/implicit_arrangement.cpp
+++ b/app/implicit_arrangement.cpp
@@ -73,6 +73,7 @@ int main(int argc, const char* argv[])
     std::vector<std::vector<size_t>> non_manifold_edges_of_vert;
     std::vector<std::vector<size_t>> shells;
     std::vector<std::vector<size_t>> arrangement_cells;
+    std::vector<std::vector<size_t>> cell_function_label;
     // record timings
     std::vector<std::string> timing_labels;
     std::vector<double> timings;
@@ -91,7 +92,7 @@ int main(int argc, const char* argv[])
     iso_pts,iso_faces,patches, patch_function_label,
     iso_edges,chains,
     non_manifold_edges_of_vert,
-    shells,arrangement_cells,
+    shells,arrangement_cells,cell_function_label,
     timing_labels,timings,
     stats_labels,stats)) {
         return -1;
@@ -109,7 +110,8 @@ int main(int argc, const char* argv[])
                     chains,
                     non_manifold_edges_of_vert,
                     shells,
-                    arrangement_cells);
+                    arrangement_cells,
+                    cell_function_label);
         //
         save_result_msh(config.output_dir + "/mesh",
                         iso_pts,

--- a/app/implicit_arrangement.cpp
+++ b/app/implicit_arrangement.cpp
@@ -73,7 +73,7 @@ int main(int argc, const char* argv[])
     std::vector<std::vector<size_t>> non_manifold_edges_of_vert;
     std::vector<std::vector<size_t>> shells;
     std::vector<std::vector<size_t>> arrangement_cells;
-    std::vector<std::vector<size_t>> cell_function_label;
+    std::vector<std::vector<bool>> cell_function_label;
     // record timings
     std::vector<std::string> timing_labels;
     std::vector<double> timings;

--- a/app/material_interface.cpp
+++ b/app/material_interface.cpp
@@ -76,7 +76,7 @@ int main(int argc, const char* argv[])
     std::vector<std::vector<size_t>> non_manifold_edges_of_vert;
     std::vector<std::vector<size_t>> shells;
     std::vector<std::vector<size_t>> material_cells;
-    std::vector<std::vector<size_t>> cell_function_label;
+    std::vector<std::vector<bool>> cell_function_label;
     // record timings
     std::vector<std::string> timing_labels;
     std::vector<double> timings;

--- a/app/material_interface.cpp
+++ b/app/material_interface.cpp
@@ -76,6 +76,7 @@ int main(int argc, const char* argv[])
     std::vector<std::vector<size_t>> non_manifold_edges_of_vert;
     std::vector<std::vector<size_t>> shells;
     std::vector<std::vector<size_t>> material_cells;
+    std::vector<std::vector<size_t>> cell_function_label;
     // record timings
     std::vector<std::string> timing_labels;
     std::vector<double> timings;
@@ -114,7 +115,8 @@ int main(int argc, const char* argv[])
                                          chains,
                                          non_manifold_edges_of_vert,
                                          shells,
-                                         material_cells);
+                                         material_cells,
+                                         cell_function_label);
         //
         save_result_msh(config.output_dir + "/mesh",
                                              MI_pts,

--- a/examples/tests/3-sphere-1.json
+++ b/examples/tests/3-sphere-1.json
@@ -1,0 +1,32 @@
+[
+    {
+        "type":"sphere",
+        "center":[
+            -0.4,
+            0.3,
+            0
+        ],
+        "radius":0.3,
+        "squared": true
+    },
+    {
+        "type":"sphere",
+        "center":[
+            0.4,
+            0.3,
+            0
+        ],
+        "radius":0.3,
+        "squared": true
+    },
+    {
+        "type":"sphere",
+        "center":[
+            0,
+            -0.3,
+            0
+        ],
+        "radius":0.3,
+        "squared": true
+    }
+]

--- a/examples/tests/3-sphere-2.json
+++ b/examples/tests/3-sphere-2.json
@@ -1,0 +1,32 @@
+[
+    {
+        "type":"sphere",
+        "center":[
+            -0.4,
+            0.3,
+            0
+        ],
+        "radius":0.3,
+        "squared": true
+    },
+    {
+        "type":"sphere",
+        "center":[
+            0.4,
+            0.3,
+            0
+        ],
+        "radius":0.3,
+        "squared": true
+    },
+    {
+        "type":"sphere",
+        "center":[
+            0,
+            0.1,
+            0
+        ],
+        "radius":0.3,
+        "squared": true
+    }
+]

--- a/examples/tests/3-sphere-3.json
+++ b/examples/tests/3-sphere-3.json
@@ -1,0 +1,32 @@
+[
+    {
+        "type":"sphere",
+        "center":[
+            -0.2,
+            0.3,
+            0
+        ],
+        "radius":0.3,
+        "squared": true
+    },
+    {
+        "type":"sphere",
+        "center":[
+            0.2,
+            0.3,
+            0
+        ],
+        "radius":0.3,
+        "squared": true
+    },
+    {
+        "type":"sphere",
+        "center":[
+            0,
+            -0.1,
+            0
+        ],
+        "radius":0.3,
+        "squared": true
+    }
+]

--- a/examples/tests/3-sphere-4.json
+++ b/examples/tests/3-sphere-4.json
@@ -1,0 +1,32 @@
+[
+    {
+        "type":"sphere",
+        "center":[
+            0,
+            0,
+            0
+        ],
+        "radius":0.2,
+        "squared": true
+    },
+    {
+        "type":"sphere",
+        "center":[
+            0,
+            0,
+            0
+        ],
+        "radius":0.3,
+        "squared": true
+    },
+    {
+        "type":"sphere",
+        "center":[
+            0,
+            0,
+            0
+        ],
+        "radius":0.4,
+        "squared": true
+    }
+]

--- a/examples/tests/3-sphere-5.json
+++ b/examples/tests/3-sphere-5.json
@@ -1,0 +1,32 @@
+[
+    {
+        "type":"sphere",
+        "center":[
+            0,
+            0,
+            0
+        ],
+        "radius":2,
+        "squared": false
+    },
+    {
+        "type":"sphere",
+        "center":[
+            0,
+            0.2,
+            0
+        ],
+        "radius":0.3,
+        "squared": false
+    },
+    {
+        "type":"sphere",
+        "center":[
+            0,
+            -0.2,
+            0
+        ],
+        "radius": -0.3,
+        "squared": false
+    }
+]

--- a/src/implicit_arrangement.cpp
+++ b/src/implicit_arrangement.cpp
@@ -29,6 +29,7 @@ bool implicit_arrangement(
         std::vector<std::vector<size_t>>& non_manifold_edges_of_vert,
         std::vector<std::vector<size_t>>& shells,
         std::vector<std::vector<size_t>>& arrangement_cells,
+        std::vector<std::vector<size_t>>& cell_function_label,
         std::vector<std::string>& timing_labels,
         std::vector<double>& timings,
         std::vector<std::string>& stats_labels,
@@ -635,6 +636,8 @@ bool implicit_arrangement(
             timings.back() = timings[num_timings - 1] - timings[num_timings - 2] - timings[num_timings - 3];
         }
     }
+    //std::vector<std::vector<size_t>> cell_function_label;
+    cell_function_label = sign_propagation(arrangement_cells, shell_of_half_patch, shells, patch_function_label, n_func);
 
     return true;
 }

--- a/src/implicit_arrangement.cpp
+++ b/src/implicit_arrangement.cpp
@@ -29,7 +29,7 @@ bool implicit_arrangement(
         std::vector<std::vector<size_t>>& non_manifold_edges_of_vert,
         std::vector<std::vector<size_t>>& shells,
         std::vector<std::vector<size_t>>& arrangement_cells,
-        std::vector<std::vector<size_t>>& cell_function_label,
+        std::vector<std::vector<bool>>& cell_function_label,
         std::vector<std::string>& timing_labels,
         std::vector<double>& timings,
         std::vector<std::string>& stats_labels,
@@ -636,7 +636,6 @@ bool implicit_arrangement(
             timings.back() = timings[num_timings - 1] - timings[num_timings - 2] - timings[num_timings - 3];
         }
     }
-    //std::vector<std::vector<size_t>> cell_function_label;
     cell_function_label = sign_propagation(arrangement_cells, shell_of_half_patch, shells, patch_function_label, n_func);
 
     return true;

--- a/src/implicit_arrangement.cpp
+++ b/src/implicit_arrangement.cpp
@@ -636,7 +636,13 @@ bool implicit_arrangement(
             timings.back() = timings[num_timings - 1] - timings[num_timings - 2] - timings[num_timings - 3];
         }
     }
-    cell_function_label = sign_propagation(arrangement_cells, shell_of_half_patch, shells, patch_function_label, n_func);
+    
+    //fetching function labels (True, False) for each cell
+    std::vector<bool> sample_function_label(n_func);
+    for (size_t i = 0; i < n_func; i++){
+        sample_function_label[i] = (funcSigns(0, i) == 1) ? true : false;
+    }
+    cell_function_label = sign_propagation(arrangement_cells, shell_of_half_patch, shells, patch_function_label, n_func, sample_function_label);
 
     return true;
 }

--- a/src/implicit_arrangement.h
+++ b/src/implicit_arrangement.h
@@ -27,6 +27,7 @@
 ///  @param[out] non_manifold_edges_of_vert         Indices of non-manifold vertices
 ///  @param[out] shells         A connected component of the boundary partitioned by the surface network; encoded by patch indices: positive patch i -> 2i, negative patch i->2i+1
 ///  @param[out] arrangement_cells          A 3D region partitioned by the surface network; encoded by a vector of shell indices
+///  @param[out] cell_function_label            A 2D boolean array for the signs of each pair of a function and an arrangement cell
 ///  @param[out] timing_labels          Labels for timing
 ///  @param[out] timings            Timing results
 ///  @param[out] stats_labels           Labels for geometry metrics
@@ -54,6 +55,7 @@ bool implicit_arrangement(
         std::vector<std::vector<size_t>>& non_manifold_edges_of_vert,
         std::vector<std::vector<size_t>>& shells,
         std::vector<std::vector<size_t>>& arrangement_cells,
+        std::vector<std::vector<size_t>>& cell_function_label,
         std::vector<std::string>& timing_labels,
         std::vector<double>& timings,
         std::vector<std::string>& stats_labels,

--- a/src/implicit_arrangement.h
+++ b/src/implicit_arrangement.h
@@ -55,7 +55,7 @@ bool implicit_arrangement(
         std::vector<std::vector<size_t>>& non_manifold_edges_of_vert,
         std::vector<std::vector<size_t>>& shells,
         std::vector<std::vector<size_t>>& arrangement_cells,
-        std::vector<std::vector<size_t>>& cell_function_label,
+        std::vector<std::vector<bool>>& cell_function_label,
         std::vector<std::string>& timing_labels,
         std::vector<double>& timings,
         std::vector<std::string>& stats_labels,

--- a/src/io.cpp
+++ b/src/io.cpp
@@ -158,7 +158,8 @@ bool save_result(const std::string& filename,
                  const std::vector<std::vector<size_t>>& chains,
                  const std::vector<std::vector<size_t>>& non_manifold_edges_of_vert,
                  const std::vector<std::vector<size_t>>& shells,
-                 const std::vector<std::vector<size_t>>& cells)
+                 const std::vector<std::vector<size_t>>& cells,
+                 const std::vector<std::vector<size_t>>& cell_function_label)
 {
     using json = nlohmann::json;
     std::ofstream fout(filename.c_str());
@@ -208,6 +209,11 @@ bool save_result(const std::string& filename,
         jCells.push_back(json(cell));
     }
     //
+    json jCell_function_label;
+    for (const auto& label : cell_function_label) {
+        jCell_function_label.push_back(json(label));
+    }
+    //
     json jOut;
     jOut["points"] = jPts;
     jOut["faces"] = jFaces;
@@ -218,6 +224,7 @@ bool save_result(const std::string& filename,
     jOut["corners"] = jCorners;
     jOut["shells"] = jShells;
     jOut["cells"] = jCells;
+    jOut["cells_label"] = jCell_function_label;
     fout << jOut << std::endl;
     fout.close();
     return true;

--- a/src/io.cpp
+++ b/src/io.cpp
@@ -159,7 +159,7 @@ bool save_result(const std::string& filename,
                  const std::vector<std::vector<size_t>>& non_manifold_edges_of_vert,
                  const std::vector<std::vector<size_t>>& shells,
                  const std::vector<std::vector<size_t>>& cells,
-                 const std::vector<std::vector<size_t>>& cell_function_label)
+                 const std::vector<std::vector<bool>>& cell_function_label)
 {
     using json = nlohmann::json;
     std::ofstream fout(filename.c_str());

--- a/src/io.h
+++ b/src/io.h
@@ -49,7 +49,7 @@ bool save_result(const std::string& filename,
                  const std::vector<std::vector<size_t>>& non_manifold_edges_of_vert,
                  const std::vector<std::vector<size_t>>& shells,
                  const std::vector<std::vector<size_t>>& cells,
-                 const std::vector<std::vector<size_t>>& cell_function_label);
+                 const std::vector<std::vector<bool>>& cell_function_label);
 
 bool save_result_msh(const std::string& filename,
                      const std::vector<std::array<double, 3>>& mesh_pts,

--- a/src/io.h
+++ b/src/io.h
@@ -48,7 +48,8 @@ bool save_result(const std::string& filename,
                  const std::vector<std::vector<size_t>>& chains,
                  const std::vector<std::vector<size_t>>& non_manifold_edges_of_vert,
                  const std::vector<std::vector<size_t>>& shells,
-                 const std::vector<std::vector<size_t>>& cells);
+                 const std::vector<std::vector<size_t>>& cells,
+                 const std::vector<std::vector<size_t>>& cell_function_label);
 
 bool save_result_msh(const std::string& filename,
                      const std::vector<std::array<double, 3>>& mesh_pts,

--- a/src/mesh_connectivity.cpp
+++ b/src/mesh_connectivity.cpp
@@ -469,7 +469,7 @@ std::vector<std::vector<bool>> sign_propagation(const std::vector<std::vector<si
     }
     for (size_t i = 0; i < n_func; i++){
         if (visited_functions[i] == false){
-            for (auto label : cell_function_label){
+            for (auto& label : cell_function_label){
                 label[i] = sample_function_label[i];
             }
         }

--- a/src/mesh_connectivity.cpp
+++ b/src/mesh_connectivity.cpp
@@ -405,7 +405,8 @@ std::vector<std::vector<bool>> sign_propagation(const std::vector<std::vector<si
                       const std::vector<size_t>& shell_of_half_patch,
                       const std::vector<std::vector<size_t>>& shells,
                       const std::vector<size_t>& patch_function_label,
-                      size_t n_func
+                      size_t n_func,
+                      const std::vector<bool>& sample_function_label
                       ){
     std::vector<size_t> shell_to_cell(shells.size());
     for (size_t i = 0; i < arrangement_cells.size(); i++){
@@ -463,6 +464,13 @@ std::vector<std::vector<bool>> sign_propagation(const std::vector<std::vector<si
                     Q.push(other_cell_index);
                 cell_function_label[other_cell_index] = current_label;
                 cell_function_label[other_cell_index][other_cell.second.first] = !other_cell.second.second;
+            }
+        }
+    }
+    for (size_t i = 0; i < n_func; i++){
+        if (visited_functions[i] == false){
+            for (auto label : cell_function_label){
+                label[i] = sample_function_label[i];
             }
         }
     }

--- a/src/mesh_connectivity.h
+++ b/src/mesh_connectivity.h
@@ -88,5 +88,20 @@ void compute_arrangement_cells(size_t num_shell,
                                const std::vector<std::pair<size_t,size_t>> &shell_links,
                                std::vector<std::vector<size_t>>& arrangement_cells);
 
+///Propagate the function labels of patches to cells.
+///
+///@param[in] arrangement_cells         Cells; each cell is a list of shells
+///@param[in] shell_of_half_patch           Map: half patch --> shell
+///@param[in] shells            Shells; each shell is a list of half patches;
+///@param[in] patch_function_label          Map: patch index --> function index
+///@param[in] n_func            The number of functions
+///
+///@return a 2D vector of `size_t` of values 1 and 0 for each cell and for each function; 1 at index `i` and `j` represents the cell `i` is inside of the implicit shape of the function `j`, and vice versa.
+
+std::vector<std::vector<size_t>> sign_propagation(const std::vector<std::vector<size_t>>& arrangement_cells,
+                      const std::vector<size_t>& shell_of_half_patch,
+                      const std::vector<std::vector<size_t>>& shells,
+                      const std::vector<size_t>& patch_function_label,
+                      size_t n_func);
 
 #endif //ROBUST_IMPLICIT_NETWORKS_MESH_CONNECTIVITY_H

--- a/src/mesh_connectivity.h
+++ b/src/mesh_connectivity.h
@@ -95,6 +95,7 @@ void compute_arrangement_cells(size_t num_shell,
 ///@param[in] shells            Shells; each shell is a list of half patches;
 ///@param[in] patch_function_label          Map: patch index --> function index
 ///@param[in] n_func            The number of functions
+///@param[in] sample_function_label         A sampled set of function labels at the first point in the grid: used to generate a sign for functions that do not appear on any of the patches.
 ///
 ///@return a 2D vector of `bool` of values `true` and `false` for each cell and for each function; `true` at index `i` and `j` represents the cell `i` is inside of the implicit shape of the function `j`, and vice versa.
 
@@ -102,6 +103,7 @@ std::vector<std::vector<bool>> sign_propagation(const std::vector<std::vector<si
                       const std::vector<size_t>& shell_of_half_patch,
                       const std::vector<std::vector<size_t>>& shells,
                       const std::vector<size_t>& patch_function_label,
-                      size_t n_func);
+                      size_t n_func,
+                      const std::vector<bool>& sample_function_label);
 
 #endif //ROBUST_IMPLICIT_NETWORKS_MESH_CONNECTIVITY_H

--- a/src/mesh_connectivity.h
+++ b/src/mesh_connectivity.h
@@ -96,9 +96,9 @@ void compute_arrangement_cells(size_t num_shell,
 ///@param[in] patch_function_label          Map: patch index --> function index
 ///@param[in] n_func            The number of functions
 ///
-///@return a 2D vector of `size_t` of values 1 and 0 for each cell and for each function; 1 at index `i` and `j` represents the cell `i` is inside of the implicit shape of the function `j`, and vice versa.
+///@return a 2D vector of `bool` of values `true` and `false` for each cell and for each function; `true` at index `i` and `j` represents the cell `i` is inside of the implicit shape of the function `j`, and vice versa.
 
-std::vector<std::vector<size_t>> sign_propagation(const std::vector<std::vector<size_t>>& arrangement_cells,
+std::vector<std::vector<bool>> sign_propagation(const std::vector<std::vector<size_t>>& arrangement_cells,
                       const std::vector<size_t>& shell_of_half_patch,
                       const std::vector<std::vector<size_t>>& shells,
                       const std::vector<size_t>& patch_function_label,

--- a/tests/test_implicit_networks.cpp
+++ b/tests/test_implicit_networks.cpp
@@ -424,7 +424,7 @@ TEST_CASE("implicit arrangement on known examples", "[IA][examples]") {
         // function label check
         std::vector<size_t> patch_gt = {2, 1, 1, 2};
         REQUIRE(patch_function_label == patch_gt);
-        std::vector<std::vector<bool>> cell_gt = {{0, 0, 1}, {0, 0, 0}, {0, 1, 1}, {0, 1, 0}};
+        std::vector<std::vector<bool>> cell_gt = {{1, 0, 1}, {1, 0, 0}, {1, 1, 1}, {1, 1, 0}};
         REQUIRE(cell_function_label == cell_gt);
     }
 }

--- a/tests/test_implicit_networks.cpp
+++ b/tests/test_implicit_networks.cpp
@@ -43,7 +43,7 @@ TEST_CASE("implicit arrangement on known examples", "[IA][examples]") {
     std::vector<std::vector<size_t>> non_manifold_edges_of_vert;
     std::vector<std::vector<size_t>> shells;
     std::vector<std::vector<size_t>> arrangement_cells;
-    std::vector<std::vector<size_t>> cell_function_label;
+    std::vector<std::vector<bool>> cell_function_label;
     // record timings
     std::vector<std::string> timing_labels;
     std::vector<double> timings;
@@ -89,7 +89,7 @@ TEST_CASE("implicit arrangement on known examples", "[IA][examples]") {
         // function label check
         std::vector<size_t> patch_gt = {0};
         REQUIRE(patch_function_label == patch_gt);
-        std::vector<std::vector<size_t>> cell_gt = {{1}, {0}};
+        std::vector<std::vector<bool>> cell_gt = {{1}, {0}};
         REQUIRE(cell_function_label == cell_gt);
     }
 
@@ -130,7 +130,7 @@ TEST_CASE("implicit arrangement on known examples", "[IA][examples]") {
         // function label check
         std::vector<size_t> patch_gt = {0};
         REQUIRE(patch_function_label == patch_gt);
-        std::vector<std::vector<size_t>> cell_gt = {{1}, {0}};
+        std::vector<std::vector<bool>> cell_gt = {{1}, {0}};
         REQUIRE(cell_function_label == cell_gt);
     }
 
@@ -172,7 +172,7 @@ TEST_CASE("implicit arrangement on known examples", "[IA][examples]") {
         // function label check
         std::vector<size_t> patch_gt = {1,0,0,1};
         REQUIRE(patch_function_label == patch_gt);
-        std::vector<std::vector<size_t>> cell_gt = {{0,1}, {0,0},{1,0},{1,1}};
+        std::vector<std::vector<bool>> cell_gt = {{0,1}, {0,0},{1,0},{1,1}};
         REQUIRE(cell_function_label == cell_gt);
     }
 
@@ -214,7 +214,7 @@ TEST_CASE("implicit arrangement on known examples", "[IA][examples]") {
         // function label check
         std::vector<size_t> patch_gt = {0,1,1,0};
         REQUIRE(patch_function_label == patch_gt);
-        std::vector<std::vector<size_t>> cell_gt = {{1,0}, {0,0},{1,1},{0,1}};
+        std::vector<std::vector<bool>> cell_gt = {{1,0}, {0,0},{1,1},{0,1}};
         REQUIRE(cell_function_label == cell_gt);
     }
     
@@ -256,7 +256,7 @@ TEST_CASE("implicit arrangement on known examples", "[IA][examples]") {
         // function label check
         std::vector<size_t> patch_gt = {0,2,1};
         REQUIRE(patch_function_label == patch_gt);
-        std::vector<std::vector<size_t>> cell_gt = {{1,0,0}, {0,0,0},{0,0,1},{0,1,0}};
+        std::vector<std::vector<bool>> cell_gt = {{1,0,0}, {0,0,0},{0,0,1},{0,1,0}};
         REQUIRE(cell_function_label == cell_gt);
     }
     
@@ -298,7 +298,7 @@ TEST_CASE("implicit arrangement on known examples", "[IA][examples]") {
         // function label check
         std::vector<size_t> patch_gt = {0, 2, 0, 2, 1, 1, 2};
         REQUIRE(patch_function_label == patch_gt);
-        std::vector<std::vector<size_t>> cell_gt = {{1, 0, 0}, {0, 0, 0}, {1, 0, 1}, {0, 0, 1}, {0, 1, 1}, {0, 1, 0}};
+        std::vector<std::vector<bool>> cell_gt = {{1, 0, 0}, {0, 0, 0}, {1, 0, 1}, {0, 0, 1}, {0, 1, 1}, {0, 1, 0}};
         REQUIRE(cell_function_label == cell_gt);
     }
     
@@ -340,7 +340,7 @@ TEST_CASE("implicit arrangement on known examples", "[IA][examples]") {
         // function label check
         std::vector<size_t> patch_gt = {0, 2, 0, 2, 1, 1, 2, 1, 0, 1, 2, 0};
         REQUIRE(patch_function_label == patch_gt);
-        std::vector<std::vector<size_t>> cell_gt = {{1, 0, 0},{0, 0, 0}, {0, 0, 1}, {1, 0, 1}, {1, 1, 0}, {1, 1, 1}, {0, 1, 1}, {0, 1, 0}};
+        std::vector<std::vector<bool>> cell_gt = {{1, 0, 0},{0, 0, 0}, {0, 0, 1}, {1, 0, 1}, {1, 1, 0}, {1, 1, 1}, {0, 1, 1}, {0, 1, 0}};
         REQUIRE(cell_function_label == cell_gt);
     }
     
@@ -382,7 +382,7 @@ TEST_CASE("implicit arrangement on known examples", "[IA][examples]") {
         // function label check
         std::vector<size_t> patch_gt = {2, 1, 0};
         REQUIRE(patch_function_label == patch_gt);
-        std::vector<std::vector<size_t>> cell_gt = {{0, 0, 1}, {0, 0, 0}, {0, 1, 1}, {1, 1, 1}};
+        std::vector<std::vector<bool>> cell_gt = {{0, 0, 1}, {0, 0, 0}, {0, 1, 1}, {1, 1, 1}};
         REQUIRE(cell_function_label == cell_gt);
     }
 

--- a/tests/test_implicit_networks.cpp
+++ b/tests/test_implicit_networks.cpp
@@ -43,6 +43,7 @@ TEST_CASE("implicit arrangement on known examples", "[IA][examples]") {
     std::vector<std::vector<size_t>> non_manifold_edges_of_vert;
     std::vector<std::vector<size_t>> shells;
     std::vector<std::vector<size_t>> arrangement_cells;
+    std::vector<std::vector<size_t>> cell_function_label;
     // record timings
     std::vector<std::string> timing_labels;
     std::vector<double> timings;
@@ -74,7 +75,7 @@ TEST_CASE("implicit arrangement on known examples", "[IA][examples]") {
                 patch_function_label,
                 iso_edges,chains,
                 non_manifold_edges_of_vert,
-                shells,arrangement_cells,
+                shells,arrangement_cells,cell_function_label,
                 timing_labels,timings,
                 stats_labels,stats);
         REQUIRE(success);
@@ -82,9 +83,14 @@ TEST_CASE("implicit arrangement on known examples", "[IA][examples]") {
         // check
         REQUIRE(patches.size() == 1);
         REQUIRE(patch_function_label.size() == 1);
-        REQUIRE(patch_function_label[0] == 0);
         REQUIRE(chains.size() == 0);
         REQUIRE(arrangement_cells.size() == 2);
+        
+        // function label check
+        std::vector<size_t> patch_gt = {0};
+        REQUIRE(patch_function_label == patch_gt);
+        std::vector<std::vector<size_t>> cell_gt = {{1}, {0}};
+        REQUIRE(cell_function_label == cell_gt);
     }
 
     SECTION("one sphere") {
@@ -110,7 +116,7 @@ TEST_CASE("implicit arrangement on known examples", "[IA][examples]") {
                 patch_function_label,
                 iso_edges,chains,
                 non_manifold_edges_of_vert,
-                shells,arrangement_cells,
+                shells,arrangement_cells,cell_function_label,
                 timing_labels,timings,
                 stats_labels,stats);
         REQUIRE(success);
@@ -118,9 +124,14 @@ TEST_CASE("implicit arrangement on known examples", "[IA][examples]") {
         // check
         REQUIRE(patches.size() == 1);
         REQUIRE(patch_function_label.size() == 1);
-        REQUIRE(patch_function_label[0] == 0);
         REQUIRE(chains.size() == 0);
         REQUIRE(arrangement_cells.size() == 2);
+        
+        // function label check
+        std::vector<size_t> patch_gt = {0};
+        REQUIRE(patch_function_label == patch_gt);
+        std::vector<std::vector<size_t>> cell_gt = {{1}, {0}};
+        REQUIRE(cell_function_label == cell_gt);
     }
 
     SECTION("plane and sphere") {
@@ -147,7 +158,7 @@ TEST_CASE("implicit arrangement on known examples", "[IA][examples]") {
                 patch_function_label,
                 iso_edges,chains,
                 non_manifold_edges_of_vert,
-                shells,arrangement_cells,
+                shells,arrangement_cells,cell_function_label,
                 timing_labels,timings,
                 stats_labels,stats);
         REQUIRE(success);
@@ -155,12 +166,14 @@ TEST_CASE("implicit arrangement on known examples", "[IA][examples]") {
         // check
         REQUIRE(patches.size() == 4);
         REQUIRE(patch_function_label.size() == 4);
-        REQUIRE(patch_function_label[0] == 1);
-        REQUIRE(patch_function_label[1] == 0);
-        REQUIRE(patch_function_label[2] == 0);
-        REQUIRE(patch_function_label[3] == 1);
         REQUIRE(chains.size() == 1);
         REQUIRE(arrangement_cells.size() == 4);
+        
+        // function label check
+        std::vector<size_t> patch_gt = {1,0,0,1};
+        REQUIRE(patch_function_label == patch_gt);
+        std::vector<std::vector<size_t>> cell_gt = {{0,1}, {0,0},{1,0},{1,1}};
+        REQUIRE(cell_function_label == cell_gt);
     }
 
     SECTION("two spheres") {
@@ -187,7 +200,7 @@ TEST_CASE("implicit arrangement on known examples", "[IA][examples]") {
                 patch_function_label,
                 iso_edges,chains,
                 non_manifold_edges_of_vert,
-                shells,arrangement_cells,
+                shells,arrangement_cells,cell_function_label,
                 timing_labels,timings,
                 stats_labels,stats);
         REQUIRE(success);
@@ -195,12 +208,182 @@ TEST_CASE("implicit arrangement on known examples", "[IA][examples]") {
         // check
         REQUIRE(patches.size() == 4);
         REQUIRE(patch_function_label.size() == 4);
-        REQUIRE(patch_function_label[0] == 0);
-        REQUIRE(patch_function_label[1] == 1);
-        REQUIRE(patch_function_label[2] == 1);
-        REQUIRE(patch_function_label[3] == 0);
         REQUIRE(chains.size() == 1);
         REQUIRE(arrangement_cells.size() == 4);
+        
+        // function label check
+        std::vector<size_t> patch_gt = {0,1,1,0};
+        REQUIRE(patch_function_label == patch_gt);
+        std::vector<std::vector<size_t>> cell_gt = {{1,0}, {0,0},{1,1},{0,1}};
+        REQUIRE(cell_function_label == cell_gt);
+    }
+    
+    SECTION("three spheres config 1") {
+        // compute function values on tet grid vertices
+        size_t n_pts = pts.size();
+        size_t n_func = 3;
+        funcVals.resize(n_pts, n_func);
+        size_t func_id;
+        
+        if (!load_functions(std::string(TEST_FILE) + "/3-sphere-1.json", pts, funcVals)) {
+            throw std::runtime_error("ERROR: Failed to load functions.");
+        }
+
+        // compute implicit arrangement
+        bool success = implicit_arrangement(
+                robust_test,
+                use_lookup,
+                use_secondary_lookup,
+                use_topo_ray_shooting,
+                //
+                pts, tets, funcVals,
+                //
+                iso_pts,iso_faces,patches,
+                patch_function_label,
+                iso_edges,chains,
+                non_manifold_edges_of_vert,
+                shells,arrangement_cells,cell_function_label,
+                timing_labels,timings,
+                stats_labels,stats);
+        REQUIRE(success);
+
+        // check
+        REQUIRE(patches.size() == 3);
+        REQUIRE(patch_function_label.size() == 3);
+        REQUIRE(chains.size() == 0);
+        REQUIRE(arrangement_cells.size() == 4);
+        
+        // function label check
+        std::vector<size_t> patch_gt = {0,2,1};
+        REQUIRE(patch_function_label == patch_gt);
+        std::vector<std::vector<size_t>> cell_gt = {{1,0,0}, {0,0,0},{0,0,1},{0,1,0}};
+        REQUIRE(cell_function_label == cell_gt);
+    }
+    
+    SECTION("three spheres config 2") {
+        // compute function values on tet grid vertices
+        size_t n_pts = pts.size();
+        size_t n_func = 3;
+        funcVals.resize(n_pts, n_func);
+        size_t func_id;
+        
+        if (!load_functions(std::string(TEST_FILE) + "/3-sphere-2.json", pts, funcVals)) {
+            throw std::runtime_error("ERROR: Failed to load functions.");
+        }
+
+        // compute implicit arrangement
+        bool success = implicit_arrangement(
+                robust_test,
+                use_lookup,
+                use_secondary_lookup,
+                use_topo_ray_shooting,
+                //
+                pts, tets, funcVals,
+                //
+                iso_pts,iso_faces,patches,
+                patch_function_label,
+                iso_edges,chains,
+                non_manifold_edges_of_vert,
+                shells,arrangement_cells,cell_function_label,
+                timing_labels,timings,
+                stats_labels,stats);
+        REQUIRE(success);
+
+        // check
+        REQUIRE(patches.size() == 7);
+        REQUIRE(patch_function_label.size() == 7);
+        REQUIRE(chains.size() == 2);
+        REQUIRE(arrangement_cells.size() == 6);
+        
+        // function label check
+        std::vector<size_t> patch_gt = {0, 2, 0, 2, 1, 1, 2};
+        REQUIRE(patch_function_label == patch_gt);
+        std::vector<std::vector<size_t>> cell_gt = {{1, 0, 0}, {0, 0, 0}, {1, 0, 1}, {0, 0, 1}, {0, 1, 1}, {0, 1, 0}};
+        REQUIRE(cell_function_label == cell_gt);
+    }
+    
+    SECTION("three spheres config 3") {
+        // compute function values on tet grid vertices
+        size_t n_pts = pts.size();
+        size_t n_func = 3;
+        funcVals.resize(n_pts, n_func);
+        size_t func_id;
+        
+        if (!load_functions(std::string(TEST_FILE) + "/3-sphere-3.json", pts, funcVals)) {
+            throw std::runtime_error("ERROR: Failed to load functions.");
+        }
+
+        // compute implicit arrangement
+        bool success = implicit_arrangement(
+                robust_test,
+                use_lookup,
+                use_secondary_lookup,
+                use_topo_ray_shooting,
+                //
+                pts, tets, funcVals,
+                //
+                iso_pts,iso_faces,patches,
+                patch_function_label,
+                iso_edges,chains,
+                non_manifold_edges_of_vert,
+                shells,arrangement_cells,cell_function_label,
+                timing_labels,timings,
+                stats_labels,stats);
+        REQUIRE(success);
+
+        // check
+        REQUIRE(patches.size() == 12);
+        REQUIRE(patch_function_label.size() == 12);
+        REQUIRE(chains.size() == 6);
+        REQUIRE(arrangement_cells.size() == 8);
+        
+        // function label check
+        std::vector<size_t> patch_gt = {0, 2, 0, 2, 1, 1, 2, 1, 0, 1, 2, 0};
+        REQUIRE(patch_function_label == patch_gt);
+        std::vector<std::vector<size_t>> cell_gt = {{1, 0, 0},{0, 0, 0}, {0, 0, 1}, {1, 0, 1}, {1, 1, 0}, {1, 1, 1}, {0, 1, 1}, {0, 1, 0}};
+        REQUIRE(cell_function_label == cell_gt);
+    }
+    
+    SECTION("three spheres config 4") {
+        // compute function values on tet grid vertices
+        size_t n_pts = pts.size();
+        size_t n_func = 3;
+        funcVals.resize(n_pts, n_func);
+        size_t func_id;
+        
+        if (!load_functions(std::string(TEST_FILE) + "/3-sphere-4.json", pts, funcVals)) {
+            throw std::runtime_error("ERROR: Failed to load functions.");
+        }
+
+        // compute implicit arrangement
+        bool success = implicit_arrangement(
+                robust_test,
+                use_lookup,
+                use_secondary_lookup,
+                use_topo_ray_shooting,
+                //
+                pts, tets, funcVals,
+                //
+                iso_pts,iso_faces,patches,
+                patch_function_label,
+                iso_edges,chains,
+                non_manifold_edges_of_vert,
+                shells,arrangement_cells,cell_function_label,
+                timing_labels,timings,
+                stats_labels,stats);
+        REQUIRE(success);
+
+        // check
+        REQUIRE(patches.size() == 3);
+        REQUIRE(patch_function_label.size() == 3);
+        REQUIRE(chains.size() == 0);
+        REQUIRE(arrangement_cells.size() == 4);
+        
+        // function label check
+        std::vector<size_t> patch_gt = {2, 1, 0};
+        REQUIRE(patch_function_label == patch_gt);
+        std::vector<std::vector<size_t>> cell_gt = {{0, 0, 1}, {0, 0, 0}, {0, 1, 1}, {1, 1, 1}};
+        REQUIRE(cell_function_label == cell_gt);
     }
 
 

--- a/tests/test_implicit_networks.cpp
+++ b/tests/test_implicit_networks.cpp
@@ -385,6 +385,46 @@ TEST_CASE("implicit arrangement on known examples", "[IA][examples]") {
         std::vector<std::vector<bool>> cell_gt = {{0, 0, 1}, {0, 0, 0}, {0, 1, 1}, {1, 1, 1}};
         REQUIRE(cell_function_label == cell_gt);
     }
+    
+    SECTION("three spheres config 5") {
+        // compute function values on tet grid vertices
+        size_t n_pts = pts.size();
+        size_t n_func = 3;
+        funcVals.resize(n_pts, n_func);
+        size_t func_id;
+        
+        if (!load_functions(std::string(TEST_FILE) + "/3-sphere-5.json", pts, funcVals)) {
+            throw std::runtime_error("ERROR: Failed to load functions.");
+        }
 
+        // compute implicit arrangement
+        bool success = implicit_arrangement(
+                robust_test,
+                use_lookup,
+                use_secondary_lookup,
+                use_topo_ray_shooting,
+                //
+                pts, tets, funcVals,
+                //
+                iso_pts,iso_faces,patches,
+                patch_function_label,
+                iso_edges,chains,
+                non_manifold_edges_of_vert,
+                shells,arrangement_cells,cell_function_label,
+                timing_labels,timings,
+                stats_labels,stats);
+        REQUIRE(success);
 
+        // check
+        REQUIRE(patches.size() == 4);
+        REQUIRE(patch_function_label.size() == 4);
+        REQUIRE(chains.size() == 1);
+        REQUIRE(arrangement_cells.size() == 4);
+        
+        // function label check
+        std::vector<size_t> patch_gt = {2, 1, 1, 2};
+        REQUIRE(patch_function_label == patch_gt);
+        std::vector<std::vector<bool>> cell_gt = {{0, 0, 1}, {0, 0, 0}, {0, 1, 1}, {0, 1, 0}};
+        REQUIRE(cell_function_label == cell_gt);
+    }
 }


### PR DESCRIPTION
Added Feature to Propagate Function Signs to all Cells

* Added `sign_propogation` function, and changed its related API and IO stream to output `cell_function label`.
* Added four configurations of three spheres model to the unit tests. 
* Adjusted other units to test for the new feature.



<img src=https://github.com/duxingyi-charles/Robust-Implicit-Surface-Networks/assets/46691179/59d26ab2-b47a-48fe-a39e-947e47957d9f height="300">



Visual verifications of the 4 configurations of three spheres. On each plot, there is an overlay of overall mesh and a cell. The cell is plot in color, and on top of it, there are TF labels of all three spherical functions for this cell. For the label, 1 means inside the function, and 0 means outside. 