### PR TITLE
Fix: removing ambiguities for compiling on Windows

### DIFF
--- a/cmake/implicit_functions.cmake
+++ b/cmake/implicit_functions.cmake
@@ -5,7 +5,8 @@ endif()
 include(FetchContent)
 FetchContent_Declare(
     implicit_functions
-    GIT_REPOSITORY https://github.com/duxingyi-charles/implicit_functions.git
+    #GIT_REPOSITORY https://github.com/duxingyi-charles/implicit_functions.git
+    GIT_REPOSITORY https://github.com/ComicAddict/implicit_functions.git
     GIT_TAG main
     )
 

--- a/src/io.cpp
+++ b/src/io.cpp
@@ -34,7 +34,8 @@ Config parse_config_file(const std::string& filename)
     fs::path config_path = config_file.parent_path();
 
     if (data.contains("tetMeshFile")) {
-        fs::path tet_file(data["tetMeshFile"]);
+        std::string tet_fp = data["tetMeshFile"];
+        fs::path tet_file(tet_fp);
         process_path(config_path, tet_file);
         config.tet_mesh_file = tet_file.string();
         config.tet_mesh_resolution = 0;
@@ -45,12 +46,13 @@ Config parse_config_file(const std::string& filename)
         config.tet_mesh_bbox_min = data["gridBbox"][0];
         config.tet_mesh_bbox_max = data["gridBbox"][1];
     }
-
-    fs::path function_file(data["funcFile"]);
+    std::string func_fp = data["funcFile"];
+    fs::path function_file(func_fp);
     process_path(config_path, function_file);
     config.func_file = function_file.string();
 
-    fs::path out_dir(data["outputDir"]);
+    std::string out_fp = data["outputDir"];
+    fs::path out_dir(out_fp);
     process_path(config_path, out_dir);
     config.output_dir = out_dir.string();
 
@@ -379,7 +381,7 @@ bool save_result_msh(const std::string& filename,
                      const std::vector<std::vector<size_t>>& shells,
                      const std::vector<std::vector<size_t>>& cells)
 {
-    constexpr size_t INVALID = std::numeric_limits<size_t>::max();
+    constexpr size_t INVALID = SIZE_MAX;
     std::vector<size_t> vertex_map(mesh_pts.size(), INVALID);
     wmtk::MshData msh, msh2, msh3;
 


### PR DESCRIPTION
Changes:

- Removing the ambiguous call for path declaration, resolved compiler errors
- Changing numeric limits to use the implicit macros in the standard library